### PR TITLE
Add macOS support for default log path detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"syscall"
 
@@ -32,11 +33,15 @@ func main() {
 	flag.IntVar(&tailer.microsecDelay, "usec", 150, "Microsecond delay to wait for next line (default 150)")
 	flag.Parse()
 
-	if os.PathSeparator == '/' {
-		// This doesn't handle MacOS at all!
+	switch runtime.GOOS {
+	case "darwin":
+		logpath = "/Library/Application Support/BigFix/BES Agent/__BESData/__Global/Logs"
+	case "linux":
 		logpath = "/var/opt/BESClient/__BESData/__Global/Logs"
-	} else {
+	case "windows":
 		logpath = "C:\\Program Files (x86)\\BigFix Enterprise\\BES Client\\__BESData\\__Global\\Logs"
+	default:
+		logpath = "/var/opt/BESClient/__BESData/__Global/Logs"
 	}
 
 	args := flag.Args()


### PR DESCRIPTION
## Summary
- Add macOS (darwin) platform detection using `runtime.GOOS`
- Set macOS default log path to `/Library/Application Support/BigFix/BES Agent/__BESData/__Global/Logs`
- Replace simple PathSeparator check with explicit OS detection via switch statement
- Maintain existing behavior for Linux and Windows platforms

## Test plan
- [ ] Build and run on macOS to verify default path detection
- [ ] Build and run on Linux to ensure existing behavior is unchanged
- [ ] Build and run on Windows to ensure existing behavior is unchanged
- [ ] Verify that custom paths via command line argument still work on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)